### PR TITLE
Add Markdown support on the client side

### DIFF
--- a/templates/method/default-standalone.hbr
+++ b/templates/method/default-standalone.hbr
@@ -50,7 +50,7 @@
                             </div>
                             <div class="description_and_url_container">
                                 <div class="description_container">
-                                    <div class="resource_description description" data-allow-edit="true" data-role="method-description">{{{description}}}</div>
+                                    <div class="resource_description markdown" data-allow-edit="true" data-role="method-description">{{{description}}}</div>
                                 </div>
                                 <h3>Resource URL</h3>
                                 <div class="url_container">
@@ -95,7 +95,7 @@
                                     {{/if}}
                         </td>
                         <td>
-                            <p class="description" data-role="description" data-allow-edit="true">{{{description}}}</p>
+                            <p class="markdown" data-role="description" data-allow-edit="true">{{{description}}}</p>
                         </td>
                     </tr>
                             {{/query-list}}
@@ -134,7 +134,7 @@
                             {{/if}}
                         </td>
                         <td style="vertical-align:middle">
-                            <p class="description" data-role="description" data-allow-edit="true">
+                            <p class="markdown" data-role="description" data-allow-edit="true">
                                 {{{ this.description }}}
                             </p>
                         </td>
@@ -174,7 +174,7 @@
                                         {{/if}}
                             </td>
                             <td>
-                                <p class="description" data-role="description" data-allow-edit="true">
+                                <p class="markdown" data-role="description" data-allow-edit="true">
                                     {{description}}
                                 </p>
                             </td>
@@ -216,7 +216,7 @@
                         {{#template-list this.parameters}}
                         <p data-scope="{{scope}}">
                             <span data-role="name">{{name}}</span>
-                            <span class="description" data-role="description">{{description}}</span>
+                            <span class="markdown" data-role="description">{{description}}</span>
                             <span data-role="defaultValue">{{defaultValue}}</span>
                             <span data-role="required">{{required}}</span>
                         </p>
@@ -300,7 +300,7 @@
                                 <span data-role="code">{{code}}</span>
                             </div>
                             <div class="method_data description">
-            <p class="description" data-role="description" data-allow-edit="true">
+            <p class="markdown" data-role="description" data-allow-edit="true">
                                     {{{description}}}
             </p>
                             </div>
@@ -626,7 +626,7 @@
         <script src="https://smartdocs.apigee.com/6/static/js/controller.js" type="text/javascript"></script>
         <script src="https://earth2marsh.github.io/gh/marked.js" type="text/javascript"></script>
 		<script>
-		var descriptions = document.getElementsByClassName("description");
+		var descriptions = document.getElementsByClassName("markdown");
         for (var i=0;i<descriptions.length;i++) { 
             descriptions[i].innerHTML = marked(descriptions[i].innerHTML);
 		}

--- a/templates/method/default-standalone.hbr
+++ b/templates/method/default-standalone.hbr
@@ -624,7 +624,7 @@
         <script src="https://smartdocs.apigee.com/6/static/js/base64_min.js" type="text/javascript"></script>
         <script src="https://smartdocs.apigee.com/6/static/js/model.js" type="text/javascript"></script>
         <script src="https://smartdocs.apigee.com/6/static/js/controller.js" type="text/javascript"></script>
-        <script src="https://www.javascriptoo.com/application/html/js/chjj/marked/marked.js" type="text/javascript"></script>
+        <script src="https://earth2marsh.github.io/gh/marked.js" type="text/javascript"></script>
 		<script>
 		var descriptions = document.getElementsByClassName("description");
         for (var i=0;i<descriptions.length;i++) { 

--- a/templates/method/default-standalone.hbr
+++ b/templates/method/default-standalone.hbr
@@ -624,13 +624,12 @@
         <script src="https://smartdocs.apigee.com/6/static/js/base64_min.js" type="text/javascript"></script>
         <script src="https://smartdocs.apigee.com/6/static/js/model.js" type="text/javascript"></script>
         <script src="https://smartdocs.apigee.com/6/static/js/controller.js" type="text/javascript"></script>
-        <script type="text/javascript" src="https://simonwaldherr.github.io/micromarkdown.js/micromarkdown.js"></script>
-				<script>
-					var descriptions = document.getElementsByClassName("description");
-
-					for (var i=0;i<descriptions.length;i++) { 
-							descriptions[i].innerHTML = micromarkdown.parse(descriptions[i].innerHTML);
-					}
-				</script>
+        <script src="https://www.javascriptoo.com/application/html/js/chjj/marked/marked.js" type="text/javascript"></script>
+		<script>
+		var descriptions = document.getElementsByClassName("description");
+        for (var i=0;i<descriptions.length;i++) { 
+            descriptions[i].innerHTML = marked(descriptions[i].innerHTML);
+		}
+		</script>
     </body>
 </html>

--- a/templates/method/default-standalone.hbr
+++ b/templates/method/default-standalone.hbr
@@ -50,7 +50,7 @@
                             </div>
                             <div class="description_and_url_container">
                                 <div class="description_container">
-                                    <div class="resource_description" data-allow-edit="true" data-role="method-description">{{{description}}}</div>
+                                    <div class="resource_description description" data-allow-edit="true" data-role="method-description">{{{description}}}</div>
                                 </div>
                                 <h3>Resource URL</h3>
                                 <div class="url_container">
@@ -95,7 +95,7 @@
                                     {{/if}}
                         </td>
                         <td>
-                            <p data-role="description" data-allow-edit="true">{{{description}}}</p>
+                            <p class="description" data-role="description" data-allow-edit="true">{{{description}}}</p>
                         </td>
                     </tr>
                             {{/query-list}}
@@ -134,7 +134,7 @@
                             {{/if}}
                         </td>
                         <td style="vertical-align:middle">
-                            <p data-role="description" data-allow-edit="true">
+                            <p class="description" data-role="description" data-allow-edit="true">
                                 {{{ this.description }}}
                             </p>
                         </td>
@@ -174,7 +174,7 @@
                                         {{/if}}
                             </td>
                             <td>
-                                <p data-role="description" data-allow-edit="true">
+                                <p class="description" data-role="description" data-allow-edit="true">
                                     {{description}}
                                 </p>
                             </td>
@@ -216,7 +216,7 @@
                         {{#template-list this.parameters}}
                         <p data-scope="{{scope}}">
                             <span data-role="name">{{name}}</span>
-                            <span data-role="description">{{description}}</span>
+                            <span class="description" data-role="description">{{description}}</span>
                             <span data-role="defaultValue">{{defaultValue}}</span>
                             <span data-role="required">{{required}}</span>
                         </p>
@@ -300,7 +300,7 @@
                                 <span data-role="code">{{code}}</span>
                             </div>
                             <div class="method_data description">
-            <p data-role="description" data-allow-edit="true">
+            <p class="description" data-role="description" data-allow-edit="true">
                                     {{{description}}}
             </p>
                             </div>
@@ -624,5 +624,13 @@
         <script src="https://smartdocs.apigee.com/6/static/js/base64_min.js" type="text/javascript"></script>
         <script src="https://smartdocs.apigee.com/6/static/js/model.js" type="text/javascript"></script>
         <script src="https://smartdocs.apigee.com/6/static/js/controller.js" type="text/javascript"></script>
+        <script type="text/javascript" src="https://simonwaldherr.github.io/micromarkdown.js/micromarkdown.js"></script>
+				<script>
+					var descriptions = document.getElementsByClassName("description");
+
+					for (var i=0;i<descriptions.length;i++) { 
+							descriptions[i].innerHTML = micromarkdown.parse(descriptions[i].innerHTML);
+					}
+				</script>
     </body>
 </html>


### PR DESCRIPTION
Since the backend deals with model metadata, it isn't responsible for doing more than generating documents from templates. By that rationale, the backend shouldn't be responsible for dealing with the format of that metadata, be it plain text, html, or markdown (supported by the Swagger 2.0 spec). In the future there may be reason to create a Handlebars helper in the backend, but for now, this is best solved at the template level.

This PR adds a "markdown" class to descriptions, and then it uses the `marked` JavaScript library to apply formatting. 

What remains to be done?
- apply markdown to CMS method and standalone index templates
- host the marked.js on the CDN and use that URL
