### PR TITLE
DEVSOL-1864: Escape curl command before displaying it

### DIFF
--- a/static/js/model.js
+++ b/static/js/model.js
@@ -1387,7 +1387,7 @@ Apigee.APIModel.Methods = function() {
     }
     requestContainerString += "</dl>";
     requestContainerElement.html(requestContainerString);
-    curlContainerElement.html("<pre>"+Apigee.curl+"</pre>");
+    curlContainerElement.html("<pre>" + Apigee.curl.replace(/&/, '&amp;').replace(/</, '&lt;').replace(/>/, '&gt;').replace(/"/, '&quot;').replace(/'/, '&#39;') + "</pre>");
     // Resquest content construction.
     bodyContent = unescape(data.requestContent);
     bodyContent = bodyContent.replace(/[^\x00-\x7F]/g, "###");


### PR DESCRIPTION
@giteshk  and @stevejs, is this the right/optimal way to do this? Bad things are happening when the body payload is XML; the browser tries to parse the XML as HTML because we have not escaped it.
