### PR TITLE
DEVSOL-1893: Only display Category label if values exist

### DIFF
--- a/templates/method/drupal-cms.hbr
+++ b/templates/method/drupal-cms.hbr
@@ -413,16 +413,19 @@
                             </p>
                         </td>
                     </tr>
-                    <tr>
-                        <td>
-                            <p class="title">Category</p>
-                        </td>
-                        <td>
-                            <p class="data" data-role="category">
-                                {{#each tags}}{{.}}{{#unless @last}},{{/unless}}{{/each}}
-                            </p>
-                        </td>
-                    </tr>
+                    {{!-- Only output Category if it exists --}}
+                    {{#if tags}}
+                        <tr>
+                            <td>
+                                <p class="title">Category</p>
+                            </td>
+                            <td>
+                                <p class="data" data-role="category">
+                                    {{#each tags}}{{.}}{{#unless @last}},{{/unless}}{{/each}}
+                                </p>
+                            </td>
+                        </tr>
+                    {{/if}}
                     </tbody>
                 </div><!--/.resource_summary -->
             </table>


### PR DESCRIPTION
Currently the _Category_ name/value pair is shown on the SmartDocs method page even if a category is not set.  The _Category_ should not be displayed unless there is a category to show.  See screenshot of example.
